### PR TITLE
Migrate changes from old repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install:
   - npm install -g grunt-cli
   - npm config set strict-ssl false
 install: npm install
+env:
+  - MONGODB_VERSION=2.4
+  - MONGODB_VERSION=3.2
 script:
   - npm test
 matrix:
@@ -27,3 +30,4 @@ matrix:
       - npm install
       - npm link fh-mbaas-api
       - npm test
+      

--- a/integration/test_storage.js
+++ b/integration/test_storage.js
@@ -194,7 +194,7 @@ module.exports = {
             callback();
           });
         },
-        async.apply(storage.updateDatasetClientWithRecords, datasetClient1.id, {}, updateRecords),
+        async.apply(storage.updateDatasetClientWithRecords, datasetClient1.id, {records: null}, updateRecords),
         function checkRecordIsRemovedFromTheDatasetClient(callback) {
           storage.readDatasetClientWithRecords(datasetClient1.id, function(err, datasetClient){
             assert.ok(!err);

--- a/lib/mongodbQueue.js
+++ b/lib/mongodbQueue.js
@@ -116,7 +116,7 @@ MongodbQueue.prototype.create = function(cb) {
           function createTTLIndex(needCreate, callback) {
             if (needCreate) {
               debug('[%s] creating ttl index: %s', self.queueName, indexName);
-              collection.createIndex({'deleted': 1}, {'expireAfterSeconds': self.queueTTL, 'backgroud': true}, callback);
+              collection.createIndex({'deleted': 1}, {'expireAfterSeconds': self.queueTTL, 'background': true}, callback);
             } else {
               debug('[%s] skip creating ttl index', self.queueName);
               return callback();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "JSON data syncronisation server",
   "main": "lib/index.js",
   "dependencies": {

--- a/scripts/posttest.sh
+++ b/scripts/posttest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-docker rm -f $(docker ps -a -q  --filter name=mongodb2.4)
+docker rm -f $(docker ps -a -q  --filter name=mongodb-fh-mbaas-api)
 echo "Mongodb Stopped"
-docker rm -f $(docker ps -a -q  --filter name=redis2.6)
+docker rm -f $(docker ps -a -q  --filter name=redis-fh-mbaas-api)
 echo "Redis Stopped"

--- a/scripts/pretest.sh
+++ b/scripts/pretest.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-echo "Starting Redis-2.6"
-docker pull redis:2.6
-docker rm -f $(docker ps -a -q  --filter name=redis2.6)
-docker run -d -p 127.0.0.1:6379:6379 --name redis2.6 redis:2.6
-echo "Starting Mongodb-2.4"
-docker pull mongo:2.4
-docker rm -f $(docker ps -a -q  --filter name=mongodb2.4)
-docker run -d -p 127.0.0.1:27017:27017 --name mongodb2.4 mongo:2.4 mongod --smallfiles
+
+REDIS_VERSION=${REDIS_VERSION:-2.6}
+MONGODB_VERSION=${MONGODB_VERSION:-2.4}
+
+echo "Starting Redis-$REDIS_VERSION"
+docker pull redis:$REDIS_VERSION
+docker rm -f $(docker ps -a -q  --filter name=redis-fh-mbaas-api)
+docker run -d -p 127.0.0.1:6379:6379 --name redis-fh-mbaas-api redis:$REDIS_VERSION
+
+echo "Starting Mongodb-$MONGODB_VERSION"
+docker pull mongo:$MONGODB_VERSION
+docker rm -f $(docker ps -a -q  --filter name=mongodb-fh-mbaas-api)
+docker run -d -p 127.0.0.1:27017:27017 --name mongodb-fh-mbaas-api mongo:$MONGODB_VERSION mongod --smallfiles
 #give it some time to complete starting
 sleep 30s


### PR DESCRIPTION
Migrated changes from fh-mbaas-api from the time when we in process of moving repos.

Changes:
- RHMAP-15491 Fix background typo
- Ensure an update object is passed to in tests
- Add MONGODB_VERSION env vars for MongoDB 2.4 & 3.2 to the travis

review: Changes were reviewed before. Just cherry picked them, but because of many structure changes I needed to merge and squash them as one