### PR TITLE
Add default callback for dropTTLIndex

### DIFF
--- a/lib/mongodbQueue.js
+++ b/lib/mongodbQueue.js
@@ -94,10 +94,10 @@ MongodbQueue.prototype.create = function(cb) {
             debug('[%s] found queue indexInfo : %j', self.queueName, indexInfo);
             var existingIndex = _.findWhere(indexInfo, {name: indexName});
 
-            if (!existingIndex) {
-              return callback(null, false);
-            } else if (existingIndex.expireAfterSeconds !== self.queueOptions.ttl) {
+            if (existingIndex && existingIndex.expireAfterSeconds !== self.queueOptions.ttl) {
               return callback(null, true);
+            } else {
+              return callback(null, false);
             }
           },
           function dropTTLIndex(needDrop, callback) {


### PR DESCRIPTION
There were cases where the callback would not be invoked when checking whether to drop the ttl index. This adds in a default.