### PR TITLE
 🐛 a few optimisations to improve performance of the sync request

### DIFF
--- a/integration/test_storage.js
+++ b/integration/test_storage.js
@@ -245,7 +245,7 @@ module.exports = {
         async.apply(storage.saveUpdate, DATASETID, ack1),
         async.apply(storage.saveUpdate, DATASETID, ack2),
         function checkSyncUpdatesCreated(callback) {
-          storage.listUpdates(DATASETID, {cuid: TESTCUID}, function(err, updates){
+          storage.listUpdates(DATASETID, {cuid: TESTCUID}, null, function(err, updates){
             assert.ok(!err);
             assert.equal(updates.length, 2);
             callback();
@@ -253,7 +253,7 @@ module.exports = {
         },
         async.apply(storage.findAndDeleteUpdate, DATASETID, ack1),
         function checkSyncUpdatesRemoved(callback) {
-          storage.listUpdates(DATASETID, {cuid: TESTCUID}, function(err, updates){
+          storage.listUpdates(DATASETID, {cuid: TESTCUID}, null, function(err, updates){
             assert.ok(!err);
             assert.equal(updates.length, 1);
             delete updates[0]._id;

--- a/lib/api-sync.js
+++ b/lib/api-sync.js
@@ -81,8 +81,25 @@ function processSyncAPI(datasetId, params, readDatasetClient, cb) {
       return callback();
     },
     addAcks: function(callback) {
-      debug('[%s] adding acks to queue. size = %d', datasetId, (params.acknowledgements && params.acknowledgements.length || 0));
-      addToQueue(params.acknowledgements, {datasetId: datasetId, cuid: cuid}, ackQueue, callback);
+      var acknowledgements = params.acknowledgements || [];
+      debug('[%s] found acks in request. size = %d', datasetId, acknowledgements.length);
+      if (syncConfig.syncReqAckLimit && syncConfig.syncReqAckLimit > 0 && acknowledgements.length > syncConfig.syncReqAckLimit) {
+        acknowledgements = acknowledgements.slice(0, syncConfig.syncReqAckLimit);
+        debug('[%s] too many acks in the request. Only process the first %d items', datasetId, acknowledgements.length);
+      }
+      debug('[%s] adding acks to queue. size = %d', datasetId, acknowledgements.length);
+      if (syncConfig.syncReqWaitForAck) {
+        debug('[%s] waiting for ack insert to complete', datasetId);
+        addToQueue(acknowledgements, {datasetId: datasetId, cuid: cuid}, ackQueue, callback);
+      } else {
+        debug('[%s] skip waiting for ack insert', datasetId);
+        addToQueue(acknowledgements, {datasetId: datasetId, cuid: cuid}, ackQueue, function(err){
+          if (err) {
+            debugError('[%s] ack insert error = %s', datasetId, err);
+          }
+        });
+        callback();
+      }
     },
     addPendings: function(callback) {
       debug('[%s] adding pendings to queue. size = %d', datasetId, (params.pending && params.pending.length || 0));
@@ -90,7 +107,12 @@ function processSyncAPI(datasetId, params, readDatasetClient, cb) {
     },
     processedUpdates: function(callback) {
       debug('[%s] list updates for client cuid = %s', datasetId, cuid);
-      syncStorage.listUpdates(datasetId, {cuid: cuid}, callback);
+      var query = {cuid: cuid};
+      var opts = {};
+      if (syncConfig.syncReqAckLimit && syncConfig.syncReqAckLimit > 0) {
+        opts.limit = syncConfig.syncReqAckLimit;
+      }
+      syncStorage.listUpdates(datasetId, query, opts, callback);
     }
   }, function(err, results) {
     if (err) {

--- a/lib/api-syncRecords.js
+++ b/lib/api-syncRecords.js
@@ -40,7 +40,7 @@ function listAppliedChangeSinceLastSync(datasetId, lastSyncEndTime, clientInfo, 
     type: SYNC_UPDATE_TYPES.APPLIED,
     cuid: clientInfo.cuid,
     timestamp: {$gt: lastSyncEndTime}
-  }, cb);
+  }, null, cb);
 }
 
 /**

--- a/lib/storage/sync-updates.js
+++ b/lib/storage/sync-updates.js
@@ -58,12 +58,18 @@ function doSaveUpdate(datasetId, acknowledgementFields, callback) {
  *
  * @param {String} datasetId
  * @param {Object} criteria
+ * @param {Object} options
  * @param {Function} callback
  */
-function doListUpdates(datasetId, criteria, callback) {
+function doListUpdates(datasetId, criteria, options, callback) {
   debug('[%s] doListUpdates criteria = %j',datasetId,criteria);
   var updatesCollection = mongoClient.collection(getDatasetUpdatesCollectionName(datasetId));
-  updatesCollection.find(criteria).toArray(function(err, updates) {
+  var docLimit = options && options.limit;
+  var cursor = updatesCollection.find(criteria);
+  if (docLimit && docLimit > 0) {
+    cursor = cursor.limit(docLimit);
+  }
+  cursor.toArray(function(err, updates) {
     if (err) {
       debugError('[%s] Failed to doListUpdates due to error %s :: criteria = %j' + criteria,datasetId,err,criteria);
       return callback(err);
@@ -99,10 +105,11 @@ module.exports = function(mongoClientImpl) {
      * List the updates that match the given list criteria
      * @param {String} datasetId
      * @param {Object} criteria the list criteria, a mongodb query object
+     * @param {Object} options options for the find option, like `limit`
      * @param {Function} callback
      */
-    listUpdates: function(datasetId, criteria, callback) {
-      return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doListUpdates)(datasetId, criteria, callback);
+    listUpdates: function(datasetId, criteria, options, callback) {
+      return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doListUpdates)(datasetId, criteria, options, callback);
     }
   };
 };

--- a/lib/sync-server.js
+++ b/lib/sync-server.js
@@ -100,7 +100,12 @@ var DEFAULT_SYNC_CONF = {
   /**@type {String} specify the maximum retention time of an inactive datasetClient. Any inactive datasetClient that is older than this period of time will be removed.*/
   datasetClientCleanerRetentionPeriod: '24h',
   /** @type {String} specify the frequency the datasetClient cleaner should run. Default every hour.*/
-  datasetClientCleanerCheckFrequency: '1h'
+  datasetClientCleanerCheckFrequency: '1h',
+
+  /** @type {Boolean} Specify if the server should wait for the ack insert to complete before returning the response for the sync request. Default is true. */
+  syncReqWaitForAck: true,
+  /** @type {Number} Specify the max number of ack items will be processed for a single request. Default is -1 (unlimited).*/
+  syncReqAckLimit: -1
 };
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 var syncStarted = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "FeedHenry Data Synchronization Server",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
We discovered that when some clients have large number of acks in the requests, the ack queue can be built up quite quickly and that will slow everything down of the system.

This change add the following optimisations:

1. adding a flag to allow skip waiting for the ack insertion to be completed in the sync requests.
2. allow developers to specify the maximum number of acks of each request to process

ping @david-martin @wtrocki 