### PR TITLE
Override cuid

### DIFF
--- a/integration/test_sync_apis.js
+++ b/integration/test_sync_apis.js
@@ -27,7 +27,7 @@ module.exports = {
         schedulerInterval: 100, 
         schedulerLockName: 'test:syncApi:lock', 
         useCache: true,
-        cuidGenerator: function(params) {
+        cuidProducer: function(params) {
           return params.__fh.cuid + params.query_params.user;
         }
     });

--- a/integration/test_sync_apis.js
+++ b/integration/test_sync_apis.js
@@ -26,7 +26,11 @@ module.exports = {
         ackWorkerInterval: 100, 
         schedulerInterval: 100, 
         schedulerLockName: 'test:syncApi:lock', 
-        useCache: true});
+        useCache: true,
+        cuidGenerator: function(params) {
+          return params.__fh.cuid + params.query_params.user;
+        }
+    });
       async.series([
         async.apply(sync.api.connect, mongoDBUrl, null, redisUrl),
         async.apply(sync.api.init, DATASETID, {syncFrequency: 1}),

--- a/lib/api-sync.js
+++ b/lib/api-sync.js
@@ -61,7 +61,7 @@ function removeUpdatesInRequest(updatesInDb, updatesInRequest) {
 function processSyncAPI(datasetId, params, readDatasetClient, cb) {
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {};
-  var cuid = syncUtil.getCuid(params);
+  var cuid = syncUtil.getCuid(params, syncConfig.cuidGenerator);
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
   var collisionCount = readDatasetClient && readDatasetClient.collisionCount ? readDatasetClient.collisionCount : 0;
   var datasetClientFields = {
@@ -148,7 +148,7 @@ function processSyncAPI(datasetId, params, readDatasetClient, cb) {
  * @param {Object} params the request body, it normally contain those fields:
  * @param {Object} params.query_params the query parameter for the dataset from the client
  * @param {Object} params.meta_data the meta data for the dataset from the client
- * @param {Object} params._fh an object added by the client sdk. it could have the `cuid` of the client
+ * @param {Object} params.__fh an object added by the client sdk. it could have the `cuid` of the client
  * @param {Array} params.pending the pending changes array
  * @param {Array} params.acknowledgements the acknowledgements from the client
  * @param {Function} cb the callback function

--- a/lib/api-sync.js
+++ b/lib/api-sync.js
@@ -61,7 +61,7 @@ function removeUpdatesInRequest(updatesInDb, updatesInRequest) {
 function processSyncAPI(datasetId, params, readDatasetClient, cb) {
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {};
-  var cuid = syncUtil.getCuid(params, syncConfig.cuidGenerator);
+  var cuid = syncConfig.cuidProducer(params);
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
   var collisionCount = readDatasetClient && readDatasetClient.collisionCount ? readDatasetClient.collisionCount : 0;
   var datasetClientFields = {

--- a/lib/api-syncRecords.js
+++ b/lib/api-syncRecords.js
@@ -5,7 +5,7 @@ var util = require('util');
 var syncUtil = require('./util');
 var SYNC_UPDATE_TYPES = require('./pending-processor').SYNC_UPDATE_TYPES;
 var convertToObject = syncUtil.convertToObject;
-var syncStorage, pendingQueue;
+var syncStorage, pendingQueue, syncConfig;
 var debug = syncUtil.debug;
 var debugError = syncUtil.debugError;
 
@@ -171,7 +171,7 @@ function computeDelta(datasetId, clientRecords, serverRecords) {
  * @param {Object} params the request body, it normally contain those fields:
  * @param {Object} params.query_params the query parameter for the dataset from the client
  * @param {Object} params.meta_data the meta data for the dataset from the client
- * @param {Object} params._fh an object added by the client sdk. it should have the `cuid` of the client
+ * @param {Object} params.__fh an object added by the client sdk. it should have the `cuid` of the client
  * @param {Object} params.clientRecs the client records
  * @param {Function} cb
  */
@@ -179,7 +179,7 @@ function syncRecords(datasetId, params, cb) {
   debug('[%s] process syncRecords request', datasetId);
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {}; //NOTE: the client doesn't send in this value for syncRecords ATM
-  var cuid = syncUtil.getCuid(params);
+  var cuid = syncUtil.getCuid(params, syncConfig && syncConfig.cuidGenerator);
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
   var clientRecords = params.clientRecs || {};
   async.waterfall([
@@ -232,8 +232,9 @@ function syncRecords(datasetId, params, cb) {
   });
 }
 
-module.exports = function(syncStorageImpl, pendingQueueImpl) {
+module.exports = function(syncStorageImpl, pendingQueueImpl, syncConfigImpl) {
   syncStorage = syncStorageImpl;
   pendingQueue = pendingQueueImpl;
+  syncConfig = syncConfigImpl;
   return syncRecords;
 };

--- a/lib/api-syncRecords.js
+++ b/lib/api-syncRecords.js
@@ -179,7 +179,7 @@ function syncRecords(datasetId, params, cb) {
   debug('[%s] process syncRecords request', datasetId);
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {}; //NOTE: the client doesn't send in this value for syncRecords ATM
-  var cuid = syncUtil.getCuid(params, syncConfig && syncConfig.cuidGenerator);
+  var cuid = syncConfig.cuidProducer(params);
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
   var clientRecords = params.clientRecs || {};
   async.waterfall([

--- a/lib/sync-server.js
+++ b/lib/sync-server.js
@@ -112,9 +112,9 @@ var DEFAULT_SYNC_CONF = {
    *  `params.meta_data`: the meta data used on the dataset
    *  `params.__fh.cuid`: the cuid generated on the client.
    * 
-   *  This function should not be provided in most of the cases. This should *ONLY* be provided if there is a chance that the clients may have duplicated cuids.
+   *  This function should not be overidden in most cases. This should *ONLY* be provided if there is a chance that the clients may have duplicated cuids.
   */
-  cuidGenerator: null
+  cuidProducer: syncUtil.getCuid
 };
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 var syncStarted = false;

--- a/lib/sync-server.js
+++ b/lib/sync-server.js
@@ -105,7 +105,16 @@ var DEFAULT_SYNC_CONF = {
   /** @type {Boolean} Specify if the server should wait for the ack insert to complete before returning the response for the sync request. Default is true. */
   syncReqWaitForAck: true,
   /** @type {Number} Specify the max number of ack items will be processed for a single request. Default is -1 (unlimited).*/
-  syncReqAckLimit: -1
+  syncReqAckLimit: -1,
+  /** @type {Function} Provide your own cuid generator. It should be a function and the `params` object will be passed to the generator. 
+   *  The `params` object will have the following fields:
+   *  `params.query_params`: the query params used on the dataset
+   *  `params.meta_data`: the meta data used on the dataset
+   *  `params.__fh.cuid`: the cuid generated on the client.
+   * 
+   *  This function should not be provided in most of the cases. This should *ONLY* be provided if there is a chance that the clients may have duplicated cuids.
+  */
+  cuidGenerator: null
 };
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 var syncStarted = false;
@@ -178,7 +187,7 @@ function start(cb) {
     },
     function initApis(callback) {
       apiSync = syncApiModule(interceptors, ackQueue, pendingQueue, syncStorage, syncConfig);
-      apiSyncRecords = syncRecordsApiModule(syncStorage, pendingQueue);
+      apiSyncRecords = syncRecordsApiModule(syncStorage, pendingQueue, syncConfig);
       return callback();
     },
     function createWorkers(callback) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,12 +54,20 @@ var sortedStringify = function(obj) {
   return str;
 };
 
-var getCuid = function(params) {
+var defaultCuidGenerator = function(params) {
   var cuid = '';
   if (params && params.__fh && params.__fh.cuid) {
     cuid = params.__fh.cuid;
   }
   return cuid;
+}
+
+var getCuid = function(params, generator) {
+  if (generator && typeof generator === 'function') {
+    return generator(params);
+  } else {
+    return defaultCuidGenerator(params);
+  }
 };
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,20 +54,12 @@ var sortedStringify = function(obj) {
   return str;
 };
 
-var defaultCuidGenerator = function(params) {
+var getCuid = function(params) {
   var cuid = '';
   if (params && params.__fh && params.__fh.cuid) {
     cuid = params.__fh.cuid;
   }
   return cuid;
-}
-
-var getCuid = function(params, generator) {
-  if (generator && typeof generator === 'function') {
-    return generator(params);
-  } else {
-    return defaultCuidGenerator(params);
-  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "FeedHenry Data Synchronization Server",
   "main": "index.js",
   "dependencies": {

--- a/test/test_api-sync.js
+++ b/test/test_api-sync.js
@@ -40,13 +40,19 @@ var resetStubs = function(){
   ackQueue.addMany.reset();
 };
 
+var cuidGenerator = function(params) {
+  return params.__fh.cuid + "_" + params.meta_data.clientId;
+};
+
 module.exports = {
   'beforeEach': function(){
     resetStubs();
   },
 
   'test api sync success': function(done) {
-    var apiSync = apiSyncModule(interceptors, ackQueue, pendingQueue, syncStorage, {});
+    var apiSync = apiSyncModule(interceptors, ackQueue, pendingQueue, syncStorage, {
+      cuidGenerator: cuidGenerator
+    });
     var acknowledgements = [{
       type: 'action',
       hash: 'ackhash',
@@ -60,7 +66,9 @@ module.exports = {
     }];
     var params = {
       query_params: {},
-      meta_data: {},
+      meta_data: {
+        clientId: 'client1'
+      },
       acknowledgements: acknowledgements,
       pending: pending,
       __fh: {
@@ -98,17 +106,17 @@ module.exports = {
       var ackItems = ackQueue.addMany.args[0][0];
       assert.equal(ackItems.length, 1);
       assert.equal(ackItems[0].datasetId, DATASETID);
-      assert.equal(ackItems[0].cuid, params.__fh.cuid);
+      assert.equal(ackItems[0].cuid, cuidGenerator(params));
 
       assert.ok(pendingQueue.addMany.calledOnce);
       var pendingItems = pendingQueue.addMany.args[0][0];
       assert.equal(pendingItems.length, 1);
       assert.equal(pendingItems[0].datasetId, DATASETID);
-      assert.equal(pendingItems[0].cuid, params.__fh.cuid);
+      assert.equal(pendingItems[0].cuid, cuidGenerator(params));
       assert.ok(pendingItems[0].meta_data);
 
       assert.ok(syncStorage.listUpdates.calledOnce);
-      assert.ok(syncStorage.listUpdates.calledWith(DATASETID, {cuid: params.__fh.cuid}));
+      assert.ok(syncStorage.listUpdates.calledWith(DATASETID, {cuid: cuidGenerator(params)}));
 
       assert.ok(interceptors.responseInterceptor.calledOnce);
 

--- a/test/test_api-sync.js
+++ b/test/test_api-sync.js
@@ -51,7 +51,7 @@ module.exports = {
 
   'test api sync success': function(done) {
     var apiSync = apiSyncModule(interceptors, ackQueue, pendingQueue, syncStorage, {
-      cuidGenerator: cuidGenerator
+      cuidProducer: cuidGenerator
     });
     var acknowledgements = [{
       type: 'action',

--- a/test/test_api-syncRecords.js
+++ b/test/test_api-syncRecords.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var sinon = require('sinon');
 var _ = require('underscore');
 var syncRecordsModule = require('../lib/api-syncRecords');
+var syncUtils = require('../lib/util');
 
 var syncStorage = {
   readDatasetClientWithRecords: sinon.stub(),
@@ -11,6 +12,10 @@ var syncStorage = {
 
 var pendingQueue = {
   search: sinon.stub()
+};
+
+var config = {
+  cuidProducer: syncUtils.getCuid
 };
 
 module.exports = {
@@ -58,7 +63,7 @@ module.exports = {
     syncStorage.listUpdates.yieldsAsync(null, appliedUpdates);
     pendingQueue.search.yieldsAsync(null, pendingChanges);
 
-    var syncRecords = syncRecordsModule(syncStorage, pendingQueue);
+    var syncRecords = syncRecordsModule(syncStorage, pendingQueue, config);
     var params = {
       clientRecs: clientRecords,
       _fh: {
@@ -89,7 +94,7 @@ module.exports = {
 
     var clientRecords = {};
 
-    var syncRecords = syncRecordsModule(syncStorage, pendingQueue);
+    var syncRecords = syncRecordsModule(syncStorage, pendingQueue, config);
     var params = {
       clientRecs: clientRecords,
       _fh: {


### PR DESCRIPTION
This PR will add a new configuration to allow developers override the CUID field.

In one customer's app, we have observed some devices have duplicated CUIDs in the requests. We are still investigating the root cause. But to unblock the customer,  we can provide a `cuidGenerator` function to allow overrides to be provided.

Ping @wtrocki @aidenkeating for review