### PR TITLE
Return error on getStats if Redis client is undefined

### DIFF
--- a/lib/sync-metrics.js
+++ b/lib/sync-metrics.js
@@ -148,33 +148,36 @@ var getStats = function(cb) {
       return input.toFixed(2) + 'ms';
     }
   }];
-  if (redisClient) {
-    async.map(metricsToFetch, function(metric, callback) {
-      var metricName = metric.metricName;
-      redisClient.lrange([statsNamespace, metricName].join(':'), 0, MAX_NUMBER, function(err, data) {
-        if (err) {
-          debugError('Failed to get values from redis for key %s  with error : %s', metricName, err);
-          return callback();
-        }
-        var stats = aggregateData(metric, data);
-        stats.name = metric.displayName;
-        return callback(null, stats)
-      });
-    }, function(err, results) {
-      if (err) {
-        return cb(err);
-      }
-      var reduced = _.reduce(results, function(sofar, result) {
-        sofar[result.name] = result;
-        delete result.name;
-        return sofar;
-      }, {});
-      return cb(null, reduced);
-    });
-  } else {
-    var redisClientError = new Error('Redis client is not initialised. An initial sync may not have been performed yet.');
+
+  if (!redisClient) {
+    var errorMessage = 'Redis client is not initialised. An initial sync may not have been performed yet.';
+    debugError(errorMessage);
+    var redisClientError = new Error(errorMessage);
     return cb(redisClientError);
   }
+
+  async.map(metricsToFetch, function(metric, callback) {
+    var metricName = metric.metricName;
+    redisClient.lrange([statsNamespace, metricName].join(':'), 0, MAX_NUMBER, function(err, data) {
+      if (err) {
+        debugError('Failed to get values from redis for key %s  with error : %s', metricName, err);
+        return callback();
+      }
+      var stats = aggregateData(metric, data);
+      stats.name = metric.displayName;
+      return callback(null, stats)
+    });
+  }, function(err, results) {
+    if (err) {
+      return cb(err);
+    }
+    var reduced = _.reduce(results, function(sofar, result) {
+      sofar[result.name] = result;
+      delete result.name;
+      return sofar;
+    }, {});
+    return cb(null, reduced);
+  });
 };
 
 module.exports = {

--- a/lib/sync-metrics.js
+++ b/lib/sync-metrics.js
@@ -148,28 +148,33 @@ var getStats = function(cb) {
       return input.toFixed(2) + 'ms';
     }
   }];
-  async.map(metricsToFetch, function(metric, callback) {
-    var metricName = metric.metricName;
-    redisClient.lrange([statsNamespace, metricName].join(':'), 0, MAX_NUMBER, function(err, data) {
+  if (redisClient) {
+    async.map(metricsToFetch, function(metric, callback) {
+      var metricName = metric.metricName;
+      redisClient.lrange([statsNamespace, metricName].join(':'), 0, MAX_NUMBER, function(err, data) {
+        if (err) {
+          debugError('Failed to get values from redis for key %s  with error : %s', metricName, err);
+          return callback();
+        }
+        var stats = aggregateData(metric, data);
+        stats.name = metric.displayName;
+        return callback(null, stats)
+      });
+    }, function(err, results) {
       if (err) {
-        debugError('Failed to get values from redis for key %s  with error : %s', metricName, err);
-        return callback();
+        return cb(err);
       }
-      var stats = aggregateData(metric, data);
-      stats.name = metric.displayName;
-      return callback(null, stats)
+      var reduced = _.reduce(results, function(sofar, result) {
+        sofar[result.name] = result;
+        delete result.name;
+        return sofar;
+      }, {});
+      return cb(null, reduced);
     });
-  }, function(err, results) {
-    if (err) {
-      return cb(err);
-    }
-    var reduced = _.reduce(results, function(sofar, result) {
-      sofar[result.name] = result;
-      delete result.name;
-      return sofar;
-    }, {});
-    return cb(null, reduced);
-  });
+  } else {
+    var redisClientError = new Error('Redis client is not initialised. An initial sync may not have been performed yet.');
+    return cb(redisClientError);
+  }
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "FeedHenry Data Synchronization Server",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Currently when calling getStats, if the first sync call has not been
made yet, an error will be thrown stating it cannot get `lrange` of undefined.

This is a messy error and doesn't explain what is actually going on.

This adds an error message explaining that the client is not
initialised and that an initial sync is required.