### PR TITLE
🐛 Fix the current value for stats

### DIFF
--- a/lib/sync-metrics.js
+++ b/lib/sync-metrics.js
@@ -71,8 +71,8 @@ var aggregateData = function(metric, records) {
     }).groupBy(function(record) {
       return record.tags[metric.groupByTag];
     }).reduce(function(reduced, groupRecords, groupKey) {
+      groupRecords = _.sortBy(groupRecords, 'ts');
       var processedData = _.reduce(groupRecords, function(memo, groupRecord) {
-        groupRecords = _.sortBy(groupRecords, 'ts');
         var value = groupRecord.fields[metric.valueField];
         memo.current = value;
         memo.numberOfRecords++;


### PR DESCRIPTION
The 'current' value of each stat should be based off the most recent
value.
This change fixes a bug where the oldest value was used instead.