### PR TITLE
🐛 Fix timing stats for MongoDB Operations & API Process times

### DIFF
--- a/lib/sync-metrics.js
+++ b/lib/sync-metrics.js
@@ -6,26 +6,26 @@ var async = require('async');
 
 var MB = 1024*1024;
 
+var metricsTitle = (process.env.FH_TITLE || 'fhsync') + '_stats';
 var METRIC_KEYS = {
-  WORKER_JOB_ERROR_COUNT: "worker-get-job-error-count",
-  WORKER_JOB_TOTAL_COUNT: "worker-job-count",
-  WORKER_JOB_FAILURE_COUNT: "worker-job-failure-count",
-  WORKER_JOB_SUCCESS_COUNT: "worker-job-success-count",
-  WORKER_JOB_PROCESS_TIME: "worker-job-process-time",
-  QUEUE_OPERATION_TIME: "queue-operation-time",
-  HANDLER_OPERATION_TIME: "sync-handler-operation-time",
-  SYNC_SCHEDULER_CHECK_TIME: "sync-scheduler-check-time",
-  SYNC_REQUEST_TOTAL_PROCESS_TIME: "sync-request-total-process-time",
-  PENDING_CHANGE_PROCESS_TIME: "pending-change-process-time",
-  SYNC_API_PROCESS_TIME: "sync-api-process-time",
-  MONGODB_OPERATION_TIME: "mongodb-operation-time",
-  WORKER_QUEUE_SIZE: "worker-queue-size"
+  WORKER_JOB_ERROR_COUNT: metricsTitle + "_worker-get-job-error-count",
+  WORKER_JOB_TOTAL_COUNT: metricsTitle + "_worker-job-count",
+  WORKER_JOB_FAILURE_COUNT: metricsTitle + "_worker-job-failure-count",
+  WORKER_JOB_SUCCESS_COUNT: metricsTitle + "_worker-job-success-count",
+  WORKER_JOB_PROCESS_TIME: metricsTitle + "_worker-job-process-time",
+  QUEUE_OPERATION_TIME: metricsTitle + "_queue-operation-time",
+  HANDLER_OPERATION_TIME: metricsTitle + "_sync-handler-operation-time",
+  SYNC_SCHEDULER_CHECK_TIME: metricsTitle + "_sync-scheduler-check-time",
+  SYNC_REQUEST_TOTAL_PROCESS_TIME: metricsTitle + "_sync-request-total-process-time",
+  PENDING_CHANGE_PROCESS_TIME: metricsTitle + "_pending-change-process-time",
+  SYNC_API_PROCESS_TIME: metricsTitle + "_sync-api-process-time",
+  MONGODB_OPERATION_TIME: metricsTitle + "_mongodb-operation-time",
+  WORKER_QUEUE_SIZE: metricsTitle + "_worker-queue-size"
 };
 
 var MAX_NUMBER = Number.MAX_SAFE_INTEGER || Number.MAX_VALUE;
 
 var statsNamespace = 'fhsyncstats';
-var metricsTitle = (process.env.FH_TITLE || 'fhsync') + '_stats';
 
 var redisClient;
 var debugError = syncUtils.debugError;
@@ -49,8 +49,7 @@ var timeAsyncFunc = function(metricKey, targetFn) {
       var timer = new Timer();
       args.push(function() {
         var timing = timer.stop();
-        var prefixedMetricKey = [metricsTitle, '_', metricKey].join('');
-        metricsClient.gauge(prefixedMetricKey, {success: !arguments[0], fn: targetFn.name}, timing);
+        metricsClient.gauge(metricKey, {success: !arguments[0], fn: targetFn.name}, timing);
         return callback.apply(null, arguments);
       });
     }


### PR DESCRIPTION
This fixes a regression introduced in
https://github.com/feedhenry/fh-sync/commit/eb543ed9dd1e6da6c2cf206428333f8aa56084ff.
The metrics key prefix will be applied to the key name at startup rather
than at metric send time. This will ensure the same key is used for both
metrics sending and retrieval.

A side-effect of this change is all other metrics will also be prefixed
with the app title, preventing cross app sending/retrieval of metrics if
more than 1 app is using the same metric backend (e.g. redis)

All API & MongoDB timing stats shown in dashboard screenshot below
![image](https://user-images.githubusercontent.com/878251/30588152-91bdd0ea-9d2d-11e7-8afc-c1799d22cd65.png)
