### PR TITLE
Rhmap 19582

### DIFF
--- a/lib/mongodbQueue.js
+++ b/lib/mongodbQueue.js
@@ -1,4 +1,4 @@
-var mongodbQ = require('mongodb-queue');
+var mongodbQ = require('fh-mongodb-queue');
 var metrics = require('./sync-metrics');
 var _ = require('underscore');
 var async = require('async');

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "backoff": "2.5.0",
     "debug": "2.6.9",
     "fh-component-metrics": "2.7.0",
+    "fh-mongodb-queue": "3.3.0",
     "mongodb": "2.1.18",
     "mongodb-lock": "0.4.0",
-    "mongodb-queue": "git+https://github.com/david-martin/mongodb-queue.git#ttl-index-01",
     "parse-duration": "0.1.1",
     "redis": "2.6.5",
     "underscore": "1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "FeedHenry Data Synchronization Server",
   "main": "index.js",
   "dependencies": {

--- a/test/test_mongodbQueue.js
+++ b/test/test_mongodbQueue.js
@@ -51,7 +51,7 @@ module.exports = {
     });
 
     var MongodbQueue = proxyquire('../lib/mongodbQueue', {
-      'mongodb-queue': function(){
+      'fh-mongodb-queue': function(){
         return mockMongodbQueue
       }
     });


### PR DESCRIPTION
## Jira link
https://issues.jboss.org/browse/RHMAP-19582

### What
Update mongodb-queue dependency to published fh-mongodb-queue npm version

## Why
To remove need for network access to github just for a fh-sync lib dependency

## How
Update dependency to point to published npm version of lib

## Verification steps
- checkout changes
- remove & re-install node_modules
- run `npm test` & verify all tests pass, specifically test_mongodbQueue 