### PR TITLE
[task]:RHMAP-20282- Update CI process to use supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: node_js
 sudo: required
 node_js:
-  - "0.10"
-  - "4.4.3"
+  - 4
+  - 6
+  - 8
 services:
   - docker
 before_install:
   - sudo apt-get update
   - sudo apt-get install --assume-yes apache2-utils
-  - npm install -g npm@2.13.5
+  - npm install -g npm@3.10.8
   - npm install -g grunt-cli
   - npm config set strict-ssl false
 install: npm install
@@ -20,9 +21,12 @@ script:
 matrix:
   include:
   # Include sync acceptance tests for node 4
-  - node_js: "4.4.3"
+  - node_js:
+      - 4
+      - 6
+      - 8
     services:
-    - docker
+      - docker
     script:
       - npm link
       - git clone https://github.com/feedhenry/sync-acceptance-testing.git


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20282

## WHAT
Update NodeJS version to use 4, 6, and 8 as follows.

```
node_js:
  - '4'
  - '6'
  - '8'
```
Update npm version to 3.10.8


## WHY
Use in the CI the currently supported versions.

## Verification Steps:
Check if the all steps in Trevis are finishing with success. 