### PR TITLE
[task] - Remove the fix npm used to run the tests in the CI/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ services:
 before_install:
   - sudo apt-get update
   - sudo apt-get install --assume-yes apache2-utils
-  - npm install -g npm@3.10.8
   - npm install -g grunt-cli
   - npm config set strict-ssl false
 install: npm install


### PR DESCRIPTION
## WHAT:

Remove the fix npm used to run the tests in the CI/Travis

## WHY:

It was checked that for each version is used one version and in this way, the test should be made with the default npm for each NodeJS version. 