### PR TITLE
Move update into callback

### DIFF
--- a/lib/pending-processor.js
+++ b/lib/pending-processor.js
@@ -131,8 +131,8 @@ function doUpdate(datasetId, pendingChange, callback) {
           if (err) {
             debugError('[%s] Failed to save collision uid = %s : err = %s', datasetId, uid, err);
           }
+          return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.COLLISION, null, callback);
         });
-        return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.COLLISION, null, callback);
       }
     }
   });


### PR DESCRIPTION
Trivial change to fix error where update is being saved without data from callback.
Fix for RHMAP-21000