### PR TITLE
add support for retrying pending changes

### DIFF
--- a/integration/test_retries.js
+++ b/integration/test_retries.js
@@ -1,0 +1,149 @@
+var sync = require('../lib');
+var assert = require('assert');
+var util = require('util');
+var async = require('async');
+var helper = require('./helper');
+var sinon = require('sinon');
+
+var mongoDBUrl = 'mongodb://127.0.0.1:27017/test_sync_api';
+var redisUrl = 'redis://127.0.0.1:6379';
+var DATASETID = 'syncIntegrationTest';
+var TESTCUID = 'syncIntegrationTestCuid';
+
+var firstCall = true;
+var testdata = {};
+
+var testCreateHandler = function(dataset_id, data, meta_data, cb){
+  console.log("test create handler called");
+  testdata.first = data;
+  return cb(null, {uid:"first", data: data});
+}
+
+var testUpdateHandler = function(dataset_id, uid, data, meta_data, cb) {
+  if (firstCall) {
+    console.log("test update handler called to return error");
+    firstCall = false;
+    return cb(new Error("injected error")); 
+  } else {
+    console.log("test update handler called to return data", data);
+    testdata.first = data;
+    return cb(null, {uid:"first", data: data});
+  }
+}
+
+var testReadHandler = function(dataset_id, uid, meta_data, cb) {
+  console.log("test read handler called to return data", testdata.first);
+  return cb(null, testdata.first);
+}
+
+var collisionHandler = sinon.stub;
+collisionHandler.yieldsAsync(null, {});
+
+module.exports = {
+  'test retry pending changes': {
+    'before': function(done) {
+      sync.api.setConfig({
+        syncWorkerInterval: 100, 
+        syncWorkerBackoff: {strategy: 'none'},
+        pendingWorkerInterval: 100, 
+        ackWorkerInterval: 100, 
+        schedulerInterval: 100, 
+        schedulerLockName: 'test:syncApi:lock', 
+        useCache: true,
+        cuidProducer: function(params) {
+          return params.__fh.cuid + params.query_params.user;
+        },
+        pendingWorkerRetryLimit: 2,
+        pendingWorkerRetryIntervalInSeconds: 1
+      });
+
+      sync.api.globalHandleCreate(testCreateHandler);
+      sync.api.globalHandleUpdate(testUpdateHandler);
+      sync.api.globalHandleRead(testReadHandler);
+      sync.api.globalHandleCollision(collisionHandler);
+      async.series([
+        async.apply(sync.api.connect, mongoDBUrl, null, redisUrl),
+        async.apply(sync.api.init, DATASETID, {syncFrequency: 1}),
+        function resetdb(callback) {
+          helper.resetDb(mongoDBUrl, DATASETID, function(err, db){
+            if (err) {
+              return callback(err);
+            }
+            mongodb = db;
+            return callback();
+          });
+        },
+        async.apply(sync.api.connect, mongoDBUrl, null, null)
+      ], done);
+    },
+    'after': function(done) {
+      sync.api.stopAll(done);
+    },
+    'invoke sync': function(done) {
+      var params = {
+        fn: 'sync',
+        query_params: {user: '1'},
+        meta_data: {token: 'testtoken'},
+        __fh: {
+          cuid: TESTCUID
+        },
+        pending: [{
+          action: 'create',
+          hash: 'a1',
+          uid: 'first',
+          post: {
+            'a': '1',
+            'user': '1'
+          }
+        }, {
+          action: 'update',
+          hash: 'a2',
+          uid: 'first',
+          pre: {
+            'a': '1',
+            'user': '1'
+          },
+          post: {
+            'a': '2',
+            'user': '1'
+          }
+        }, {
+          action: 'update',
+          hash: 'a3',
+          uid: 'first',
+          pre: {
+            'a': '2',
+            'user': '1'
+          },
+          post: {
+            'a': '3',
+            'user': '1'
+          }
+        }]
+      };
+      async.series([
+        function invokeSync(callback) {
+          sync.api.invoke(DATASETID, params, function(err, response){
+            assert.ok(!err, util.inspect(err));
+            assert.ok(response);
+            callback();
+          });
+        },
+        function waitForSyncLoopComplete(callback){
+          setTimeout(callback, 4000);
+        },
+        function checkData(callback) {
+          var data = testdata.first;
+          //if the retry works, the data should be updated
+          assert.equal(data.a, '3');
+          //there should be no collision
+          assert.ok(!collisionHandler.called);
+          callback();
+        }
+      ], function(err){
+        assert.ok(!err);
+        done();
+      });
+    }
+  }
+}

--- a/lib/pending-processor.js
+++ b/lib/pending-processor.js
@@ -3,8 +3,11 @@ var debug = syncUtil.debug;
 var debugError = syncUtil.debugError;
 var metrics = require('./sync-metrics');
 var util = require('util');
+var _ = require("underscore");
 
 var syncStorage, dataHandlers, hashProvider, metricsClient;
+
+var retryLimit = 1;
 
 //TODO: move this to the storage.js file
 var SYNC_UPDATE_TYPES = {
@@ -14,6 +17,13 @@ var SYNC_UPDATE_TYPES = {
 };
 
 function saveUpdate(datasetId, pendingChange, type, msg, callback) {
+  if (type !== SYNC_UPDATE_TYPES.APPLIED && pendingChange.tries < retryLimit) {
+    //if the pending change can not be applied, but it hasn't reach the retry limit, 
+    //let's not do anything and just leave it in the queue by returning an error. 
+    //it will be tried again.
+    //evetually when pendingChange.tries == retryLimit, the right status will be saved.
+    return callback(msg || "retry"); 
+  }
   var syncUpdateFields = {
     type: type,
     cuid: pendingChange.cuid,
@@ -30,6 +40,13 @@ function saveUpdate(datasetId, pendingChange, type, msg, callback) {
 }
 
 function handleCollision(datasetId, metaData, pendingChange, dataHash, callback) {
+  if (pendingChange.tries < retryLimit) {
+    //it is possible that a collision is caused because there is a previous change is being retried.
+    //in this case we don't want to log the collision as it is not true.
+    //so just ignore it for now, let the change to be tried again later.
+    //eventually when pendingChange.tries == retryLimit, if the collision still exists, it will be logged.
+    return callback(new Error("waiting for retry")); 
+  }
   var collisionFields = {
     uid: pendingChange.uid,
     hash: dataHash,
@@ -220,11 +237,14 @@ function applyPendingChange(pendingChange, tries, callback) {
     return callback();
   }
   debug('[%s] processPending :: item = %j', datasetId, pendingChange);
-  if (tries > 1) {
-    //the pendingChange has been processed before but it didn't complete, most likely the process crashedd. Mark it as failed
+  if (tries > retryLimit) {
+    //the pendingChange has been processed before. Mark it as failed
     debugError('[%s] processPending failed :: tries = %d  :: item = %j', datasetId, tries, pendingChange);
     return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.FAILED, "crashed", callback);
   }
+
+  pendingChange.tries = tries;
+
   var action = pendingChange.action.toLowerCase();
 
   var timer = metrics.startTimer();
@@ -250,11 +270,14 @@ function applyPendingChange(pendingChange, tries, callback) {
   }
 }
 
-module.exports = function(syncStorageImpl, dataHandlersImpl, hashProviderImpl, metricsClientImpl) {
+module.exports = function(syncStorageImpl, dataHandlersImpl, hashProviderImpl, metricsClientImpl, pendingWorkerRetryLimit) {
   syncStorage = syncStorageImpl;
   dataHandlers = dataHandlersImpl;
   hashProvider = hashProviderImpl;
   metricsClient = metricsClientImpl;
+  if (_.isNumber(pendingWorkerRetryLimit) && pendingWorkerRetryLimit > 0) {
+    retryLimit = pendingWorkerRetryLimit
+  }
   return function(pendingChangeRequest, callback) {
     var pendingChange = pendingChangeRequest.payload;
     var tries = pendingChangeRequest.tries;

--- a/lib/pending-processor.js
+++ b/lib/pending-processor.js
@@ -22,7 +22,7 @@ function saveUpdate(datasetId, pendingChange, type, msg, callback) {
     //let's not do anything and just leave it in the queue by returning an error. 
     //it will be tried again.
     //evetually when pendingChange.tries == retryLimit, the right status will be saved.
-    return callback(msg || "retry"); 
+    return callback(new Error(msg || "retry")); 
   }
   var syncUpdateFields = {
     type: type,

--- a/lib/sync-server.js
+++ b/lib/sync-server.js
@@ -55,6 +55,13 @@ var DEFAULT_SYNC_CONF = {
    * Default strategy is `exp` (exponential) with a max delay of 60s. The min value will always be the same as `pendingWorkerInterval`
    * The other valid strategy is `fib` (fibonacci). Set it to anything else will disable the backoff behavior */
   pendingWorkerBackoff: {strategy: 'exp', max: 60*1000},
+  /** @type {Number} specify the maximum number of times the pending worker should retry applying a pending change before considering it can not be applied. Must be greater than 0. */
+  pendingWorkerRetryLimit: 1,
+  /** @type {Number} specify the minimum gap between each retry of applying a pending change. 
+   *  Please note that this is just a minimum value as the worker interval value will also affect when a pending change will actually be retried.
+   *  For example, if the worker is scheduled to run the next job in 20 seconds, then the pending change will be retried in 20 seconds if it's the only one in the queue.
+  */
+  pendingWorkerRetryIntervalInSeconds: 10, 
   /** @type {Number} how often ack workers should check for the next job, in ms. Default: 1 */
   ackWorkerInterval: 1,
   /** @type {Number} the concurrency value of the ack workers. Default is 1. Can set to 0 to disable the ackWorker completely */
@@ -176,7 +183,7 @@ function start(cb) {
   async.series([
     function createQueues(callback) {
       ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, syncLock, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
-      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, syncLock, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
+      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, syncLock, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL, visibility: syncConfig.pendingWorkerRetryIntervalInSeconds});
       syncQueue = new MongodbQueue('fhsync_queue', metricsClient, syncLock, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
 
       async.parallel([
@@ -215,7 +222,7 @@ function start(cb) {
         ackWorkers.push(ackWorker);
       }
 
-      var pendingProcessorImpl = pendingProcessor(syncStorage, dataHandlers, hashProvider, metricsClient);
+      var pendingProcessorImpl = pendingProcessor(syncStorage, dataHandlers, hashProvider, metricsClient, syncConfig.pendingWorkerRetryLimit);
       var pendingWorkerOpts = {
         name: 'pending_worker',
         interval: syncConfig.pendingWorkerInterval,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-sync",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "description": "FeedHenry Data Synchronization Server",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
# What

This PR introduces a new feature to allow the pending changes to be retried. The number of retries and the retry interval can be configured by developers.

# Why

This is related to issue: https://issues.jboss.org/browse/RHMAP-21014.

What happens is that sometimes the custom sync handlers could fail occasionally. At the moment, when an error occurred, there is no retry mechanism and the pending change is simply treated as processed and later on the client data will be reverted. This will cause some confusion to both users and developers and the sync server itself should allow occasional failures from the sync handlers.

# To test

* Run the new integration test, or
* Deploy a new cloud app and use this version of fh-sync. Then make sure the update custom handler will fail on the first call but should succeed on the subsequent calls. Run the sync app as normal, but you should see the data will be updated eventually in the backend and the client data is not reverted back.


ping @wtrocki @camilamacedo86 @shannon 
