### PR TITLE
Fix to cope with race condition with multiple refs for one sync record

### DIFF
--- a/lib/storage/dataset-clients.js
+++ b/lib/storage/dataset-clients.js
@@ -154,6 +154,8 @@ function upsertOrDeleteDatasetRecords(datasetId, datasetClientId, records, cb) {
     } else if (op === 'delete') {
       //remove the ref
       update['$pull'] = {'refs': datasetClientId};
+      // also set the hash to null to handle race condition when multiple refs associated with single record
+      update['$set']['hash'] = null;
     }
     datasetRecordsCol.findOneAndUpdate({uid: record.uid}, update, {upsert: true, returnOriginal: false}, function(err, updated) {
       if (err) {


### PR DESCRIPTION
This PR adds a fix to a scenario where there are multiple refs against a single dataset local record.  In certain circumstances the record can have data null but with up to date hash.  In this case the record is never updated until the hash is removed.